### PR TITLE
fix: enforce protocol-favoring rounding to mitigate supply/withdraw extraction

### DIFF
--- a/contracts/protocol/libraries/logic/GenericLogic.sol
+++ b/contracts/protocol/libraries/logic/GenericLogic.sol
@@ -229,7 +229,7 @@ library GenericLogic {
       user
     );
     if (userTotalDebt != 0) {
-      userTotalDebt = userTotalDebt.rayMul(reserve.getNormalizedDebt());
+      userTotalDebt = userTotalDebt.rayMulRoundUp(reserve.getNormalizedDebt());
     }
 
     userTotalDebt = userTotalDebt + IERC20(reserve.stableDebtTokenAddress).balanceOf(user);
@@ -259,7 +259,7 @@ library GenericLogic {
   ) private view returns (uint256) {
     uint256 normalizedIncome = reserve.getNormalizedIncome();
     uint256 balance = (
-      IScaledBalanceToken(reserve.aTokenAddress).scaledBalanceOf(user).rayMul(normalizedIncome)
+      IScaledBalanceToken(reserve.aTokenAddress).scaledBalanceOf(user).rayMulRoundDown(normalizedIncome)
     ) * assetPrice;
 
     unchecked {

--- a/contracts/protocol/libraries/math/WadRayMath.sol
+++ b/contracts/protocol/libraries/math/WadRayMath.sol
@@ -92,6 +92,66 @@ library WadRayMath {
   }
 
   /**
+   * @notice Multiplies two ray, rounding down (truncating)
+   * @param a Ray
+   * @param b Ray
+   * @return c = a raymul b, rounded down
+   */
+  function rayMulRoundDown(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    assembly {
+      if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_RAY), b))))) {
+        revert(0, 0)
+      }
+      c := div(mul(a, b), RAY)
+    }
+  }
+
+  /**
+   * @notice Multiplies two ray, rounding up
+   * @param a Ray
+   * @param b Ray
+   * @return c = a raymul b, rounded up
+   */
+  function rayMulRoundUp(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    assembly {
+      if iszero(or(iszero(b), iszero(gt(a, div(sub(not(0), HALF_RAY), b))))) {
+        revert(0, 0)
+      }
+      c := div(add(mul(a, b), sub(RAY, 1)), RAY)
+    }
+  }
+
+  /**
+   * @notice Divides two ray, rounding down (truncating)
+   * @param a Ray
+   * @param b Ray
+   * @return c = a raydiv b, rounded down
+   */
+  function rayDivRoundDown(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    assembly {
+      if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), RAY))))) {
+        revert(0, 0)
+      }
+      c := div(mul(a, RAY), b)
+    }
+  }
+
+  /**
+   * @notice Divides two ray, rounding up
+   * @param a Ray
+   * @param b Ray
+   * @return c = a raydiv b, rounded up
+   */
+  function rayDivRoundUp(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    assembly {
+      if or(iszero(b), iszero(iszero(gt(a, div(sub(not(0), div(b, 2)), RAY))))) {
+        revert(0, 0)
+      }
+      c := div(add(mul(a, RAY), sub(b, 1)), b)
+    }
+  }
+
+  /**
    * @dev Casts ray down to wad
    * @dev assembly optimized for improved gas savings, see https://twitter.com/transmissions11/status/1451131036377571328
    * @param a Ray

--- a/contracts/protocol/tokenization/AToken.sol
+++ b/contracts/protocol/tokenization/AToken.sol
@@ -128,7 +128,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
   function balanceOf(
     address user
   ) public view virtual override(IncentivizedERC20, IERC20) returns (uint256) {
-    return super.balanceOf(user).rayMul(POOL.getReserveNormalizedIncome(_underlyingAsset));
+    return super.balanceOf(user).rayMulRoundDown(POOL.getReserveNormalizedIncome(_underlyingAsset));
   }
 
   /// @inheritdoc IERC20
@@ -139,7 +139,7 @@ contract AToken is VersionedInitializable, ScaledBalanceTokenBase, EIP712Base, I
       return 0;
     }
 
-    return currentSupplyScaled.rayMul(POOL.getReserveNormalizedIncome(_underlyingAsset));
+    return currentSupplyScaled.rayMulRoundDown(POOL.getReserveNormalizedIncome(_underlyingAsset));
   }
 
   /// @inheritdoc IAToken

--- a/contracts/protocol/tokenization/VariableDebtToken.sol
+++ b/contracts/protocol/tokenization/VariableDebtToken.sol
@@ -84,7 +84,7 @@ contract VariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IVariableDe
       return 0;
     }
 
-    return scaledBalance.rayMul(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
+    return scaledBalance.rayMulRoundUp(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
   }
 
   /// @inheritdoc IVariableDebtToken
@@ -112,7 +112,7 @@ contract VariableDebtToken is DebtTokenBase, ScaledBalanceTokenBase, IVariableDe
 
   /// @inheritdoc IERC20
   function totalSupply() public view virtual override returns (uint256) {
-    return super.totalSupply().rayMul(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
+    return super.totalSupply().rayMulRoundUp(POOL.getReserveNormalizedVariableDebt(_underlyingAsset));
   }
 
   /// @inheritdoc EIP712Base

--- a/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
+++ b/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol
@@ -69,7 +69,7 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
     uint256 amount,
     uint256 index
   ) internal returns (bool) {
-    uint256 amountScaled = amount.rayDiv(index);
+    uint256 amountScaled = amount.rayDivRoundDown(index);
     require(amountScaled != 0, Errors.INVALID_MINT_AMOUNT);
 
     uint256 scaledBalance = super.balanceOf(onBehalfOf);
@@ -97,7 +97,7 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
    * @param index The variable debt index of the reserve
    */
   function _burnScaled(address user, address target, uint256 amount, uint256 index) internal {
-    uint256 amountScaled = amount.rayDiv(index);
+    uint256 amountScaled = amount.rayDivRoundUp(index);
     require(amountScaled != 0, Errors.INVALID_BURN_AMOUNT);
 
     uint256 scaledBalance = super.balanceOf(user);
@@ -139,7 +139,7 @@ abstract contract ScaledBalanceTokenBase is MintableIncentivizedERC20, IScaledBa
     _userState[sender].additionalData = index.toUint128();
     _userState[recipient].additionalData = index.toUint128();
 
-    super._transfer(sender, recipient, amount.rayDiv(index).toUint128());
+    super._transfer(sender, recipient, amount.rayDivRoundUp(index).toUint128());
 
     if (senderBalanceIncrease > 0) {
       emit Transfer(address(0), sender, senderBalanceIncrease);


### PR DESCRIPTION
## Summary

Enforces protocol-favoring rounding in all critical supply/withdraw/borrow/repay paths to mitigate the well-known rounding extraction vulnerability (same class as HypurrFi/Aave V3 pre-3.5 bug).

## The Bug

sparklend-v1-core uses half-up (banker's) rounding everywhere via `WadRayMath.rayMul` / `rayDiv`. This means supply/withdraw and borrow/repay cycles can extract value from the protocol because rounding sometimes favors the user instead of always favoring the protocol. Each cycle can extract up to 1 ray (1e-27) of value, but this is exploitable at scale with gas-cheap L2 deployments or flash loans.

## Changes

### 1. `WadRayMath.sol` — New rounding variants
Added four new functions: `rayMulRoundDown`, `rayMulRoundUp`, `rayDivRoundDown`, `rayDivRoundUp`. These use the same overflow checks as the existing `rayMul`/`rayDiv` but truncate (round down) or round up instead of half-up rounding.

### 2. `ScaledBalanceTokenBase.sol` — Mint/Burn/Transfer
- **`_mintScaled`**: `rayDiv` → `rayDivRoundDown` — supply mints ≤ shares (user gets fewer or equal shares)
- **`_burnScaled`**: `rayDiv` → `rayDivRoundUp` — withdraw burns ≥ shares (protocol releases less underlying)
- **`_transfer`**: `rayDiv` → `rayDivRoundUp` — transfer moves ≥ shares from sender

### 3. `AToken.sol` — Balance/Supply views
- `balanceOf`: `rayMul` → `rayMulRoundDown` — user sees conservative balance
- `totalSupply`: `rayMul` → `rayMulRoundDown` — total supply never overstated

### 4. `VariableDebtToken.sol` — Debt views
- `balanceOf`: `rayMul` → `rayMulRoundUp` — debt never understated
- `totalSupply`: `rayMul` → `rayMulRoundUp` — total debt never understated

### 5. `GenericLogic.sol` — Health factor
- Collateral value: `rayMul` → `rayMulRoundDown` — conservative collateral
- Debt value: `rayMul` → `rayMulRoundUp` — conservative debt
- Result: health factor is never overstated, making liquidation boundaries safer

## Principle

**Every rounding decision favors the protocol:**
- Assets/collateral: round DOWN (user gets less)
- Debt/shares-burned: round UP (user owes more)

This is minimal mitigation — no architectural changes, no new storage, no interface changes.